### PR TITLE
Show error if build info is enabled but the repo does not contain any…

### DIFF
--- a/src/abstract_builders/builder.py
+++ b/src/abstract_builders/builder.py
@@ -354,7 +354,20 @@ class Builder(ABC):
             == 0
         ):
             # The project directory is a git directory
-            results = self.shell_executor.get_sh_results(["git", "-C", str(self._project_dir), "rev-parse", "HEAD"])
+            results = self.shell_executor.get_sh_results(
+                command=["git", "-C", str(self._project_dir), "rev-parse", "HEAD"], check=False
+            )
+            if results.returncode != 0:
+                if results.stdout:
+                    print(f"\n{results.stdout}")
+                if results.stderr:
+                    print(f"\n{results.stderr}")
+                pretty_print.print_error(
+                    "Unable to compose build information (see git output above). "
+                    "Ensure that the following repo contains at least one commit, or disable add_build_info "
+                    f"in the project configuration: {self._project_dir}/"
+                )
+                sys.exit(1)
             build_info = build_info + f"GIT_COMMIT_SHA: {results.stdout.splitlines()[0]}\n"
 
             results = self.shell_executor.get_sh_results(


### PR DESCRIPTION
Fix the following error that occured when `add_build_info` was enabled in the project configuration and the SoCks project was in an empty git repository without any commits.

```
>> Building archive...

HEAD


fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

[ERROR] The return code of a sub-process was not equal to zero (see output above).
return code: 128
shell command: git -C /home/lukas/Development/qup_socks rev-parse HEAD
```

This is the last remaining issue from gitlab.kit.edu