### PR TITLE
Enable output scrolling in Vivado Hog builder

### DIFF
--- a/src/amd_zynqmp_support/zynqmp_amd_vivado_hog_builder.py
+++ b/src/amd_zynqmp_support/zynqmp_amd_vivado_hog_builder.py
@@ -115,6 +115,8 @@ class ZynqMP_AMD_Vivado_Hog_Builder(AMD_Builder):
             commands=create_vivado_project_commands,
             dirs_to_mount=[(pathlib.Path(self._amd_tools_path), "ro"), (self._repo_dir, "Z")],
             print_commands=True,
+            logfile=self._block_temp_dir / "build_project.log",
+            output_scrolling=True,
         )
 
     def build_vivado_project(self):
@@ -169,6 +171,8 @@ class ZynqMP_AMD_Vivado_Hog_Builder(AMD_Builder):
                 commands=vivado_build_commands,
                 dirs_to_mount=[(pathlib.Path(self._amd_tools_path), "ro"), (self._repo_dir, "Z")],
                 print_commands=True,
+                logfile=self._block_temp_dir / "build.log",
+                output_scrolling=True,
             )
 
             # Create symlinks to the output files


### PR DESCRIPTION
Enable output scrolling in the Vivado Hog builder to match the behavior of the other Vivado project builders.