### PR TITLE
Fix image generation with deb12/podman

### DIFF
--- a/src/abstract_builders/debian_rootfs_builder.py
+++ b/src/abstract_builders/debian_rootfs_builder.py
@@ -165,7 +165,7 @@ class Debian_RootFS_Builder(File_System_Builder):
                 f"fi",
                 'printf "\nInstall the base os via debootstrap...\n\n"',
                 # The 'Minimal Install' group consists of the 'Core' group and optionally the 'Standard' and 'Guest Agents' groups
-                f"fakeroot debootstrap --arch={self._target_arch_dist} {self.block_cfg.project.release} {self._build_dir} {self.block_cfg.project.mirror}",
+                f"debootstrap --arch={self._target_arch_dist} {self.block_cfg.project.release} {self._build_dir} {self.block_cfg.project.mirror}",
                 # The QEMU binary if only required during build, so delete it if it exists
                 f"rm -f {self._build_dir}/usr/bin/qemu-{self._target_arch_qemu}-static",
             ]

--- a/src/abstract_builders/debian_rootfs_builder.py
+++ b/src/abstract_builders/debian_rootfs_builder.py
@@ -165,7 +165,7 @@ class Debian_RootFS_Builder(File_System_Builder):
                 f"fi",
                 'printf "\nInstall the base os via debootstrap...\n\n"',
                 # The 'Minimal Install' group consists of the 'Core' group and optionally the 'Standard' and 'Guest Agents' groups
-                f"debootstrap --arch={self._target_arch_dist} {self.block_cfg.project.release} {self._build_dir} {self.block_cfg.project.mirror}",
+                f"fakeroot debootstrap --arch={self._target_arch_dist} {self.block_cfg.project.release} {self._build_dir} {self.block_cfg.project.mirror}",
                 # The QEMU binary if only required during build, so delete it if it exists
                 f"rm -f {self._build_dir}/usr/bin/qemu-{self._target_arch_qemu}-static",
             ]

--- a/src/socks/container/debian-rootfs-build-env-debian12.containerfile
+++ b/src/socks/container/debian-rootfs-build-env-debian12.containerfile
@@ -5,10 +5,18 @@ FROM socks-local/socks-base-debian12:latest
 COPY --from=qemu /usr/bin/qemu-*-static /usr/bin
 
 # Install required packages to build the base RootFS
-RUN apt install -y debootstrap debian-archive-keyring && \
+RUN apt install -y debootstrap debian-archive-keyring fakeroot && \
 # Remove this package to disable the architecture check of debootstrap (https://github.com/RPi-Distro/pi-gen/issues/603)
     apt purge -y arch-test && \
 # Install required packages to modify the base RootFS
-    apt install -y rsync fakeroot && \
+    apt install -y rsync && \
 # Install required packages to package the RootFS
     apt install -y tar pigz pixz
+# Create an 'alias' for 'debootstrap', because it must be run in a fakeroot environment when using rootless Podman
+# and a Debian 12 container, even if the user inside the container has root privileges.
+# (https://github.com/podman-container-tools/podman/issues/4619)
+RUN printf '%s\n' \
+    '#!/bin/sh' \
+    'echo "Info: debootstrap is wrapped so that it runs in a fakeroot environment (required only for Debian 12 containers)"' \
+    'exec fakeroot /usr/sbin/debootstrap "$@"' > /usr/local/bin/debootstrap && \
+    chmod +x /usr/local/bin/debootstrap

--- a/src/socks/container/debian-rootfs-build-env-debian12.containerfile
+++ b/src/socks/container/debian-rootfs-build-env-debian12.containerfile
@@ -9,6 +9,6 @@ RUN apt install -y debootstrap debian-archive-keyring && \
 # Remove this package to disable the architecture check of debootstrap (https://github.com/RPi-Distro/pi-gen/issues/603)
     apt purge -y arch-test && \
 # Install required packages to modify the base RootFS
-    apt install -y rsync && \
+    apt install -y rsync fakeroot && \
 # Install required packages to package the RootFS
     apt install -y tar pigz pixz


### PR DESCRIPTION
When running with the debian12 build containers, creating the target rootfs with debootstrap fails with permission denied. This was traced to debootstrap running mknod when the container is run in user mode, which "never" has CAP_MKNOD (non-root users typically don't have this capability).

The workaround is running debootstrap under fakeroot, which avoids the kernel mknod calls and runs successfully. This commit:

 - applies this workaround unconditionally 😅.
 - installs fakeroot to the debian12 base container

Alternatively, podman could be run as root, modifying its cmdline to add CAP_MKNOD.

Reference for the workaround:
https://github.com/podman-container-tools/podman/issues/4619